### PR TITLE
Created SplitPane component

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -54,10 +54,10 @@ gulp.task "libs_js", ->
 gulp.task "copy_fonts", ->
   return gulp.src(["./bower_components/bootstrap/dist/fonts/*"]).pipe(gulp.dest("./dist/fonts/"))
 
-# gulp.task "index_css", ->
-#   return gulp.src("./src/index.css")
-#     .pipe(rework(reworkNpm("./src/")))
-#     .pipe(gulp.dest("./dist/css/"))
+gulp.task "index_css", ->
+ return gulp.src("./src/index.css")
+   .pipe(rework(reworkNpm("./src/")))
+   .pipe(gulp.dest("./dist/css/"))
 
 gulp.task 'copy_assets', ->
   return gulp.src("assets/**/*")
@@ -69,7 +69,7 @@ gulp.task "demo", gulp.parallel([
   "libs_css"
   "copy_fonts"
   "copy_assets"
-  # "index_css"
+  "index_css"
 ])
 
 # gulp.task 'watch', gulp.series([

--- a/src/Divider.coffee
+++ b/src/Divider.coffee
@@ -1,0 +1,23 @@
+React = require 'react'
+H = React.DOM
+
+module.exports = class Divider extends React.Component
+  constructor: ->
+    super
+    @state = { 
+      
+    }
+
+  onMouseDown: (event) => 
+    @props.onMouseDown(event)
+
+  render: ->
+    classNames = ["divider"]
+    style = {}
+
+    if @props.split is "vertical"
+      classNames.push("vertical")
+    if @props.split is "horizontal"
+      classNames.push("horizontal")
+      
+    H.div {style: style, className: classNames.join(" "), onMouseDown: @onMouseDown}

--- a/src/Divider.coffee
+++ b/src/Divider.coffee
@@ -2,22 +2,20 @@ React = require 'react'
 H = React.DOM
 
 module.exports = class Divider extends React.Component
-  constructor: ->
-    super
-    @state = { 
-      
-    }
+  
+  @propTypes: {
+    split: React.PropTypes.oneOf(['vertical', 'horizontal']).isRequired
+  }
 
   onMouseDown: (event) => 
     @props.onMouseDown(event)
 
   render: ->
     classNames = ["divider"]
-    style = {}
 
     if @props.split is "vertical"
       classNames.push("vertical")
     if @props.split is "horizontal"
       classNames.push("horizontal")
       
-    H.div {style: style, className: classNames.join(" "), onMouseDown: @onMouseDown}
+    H.div {className: classNames.join(" "), onMouseDown: @onMouseDown}

--- a/src/Divider.coffee
+++ b/src/Divider.coffee
@@ -1,11 +1,23 @@
+#
+# Divider
+# 
+# Internally used by SplitPane to create the draggable divider between 2 panes
+#
+# Vertical splitpane divider gets the classes "divider vertical"
+# Horizontal splitpane divider gets the classes "divider horizontal"
+
+
 React = require 'react'
 H = React.DOM
 
 module.exports = class Divider extends React.Component
   
   @propTypes: {
-    split: React.PropTypes.oneOf(['vertical', 'horizontal']).isRequired
+    split: React.PropTypes.oneOf(['vertical', 'horizontal'])
   }
+
+  @defaultProps: ->
+    split: 'vertical'
 
   onMouseDown: (event) => 
     @props.onMouseDown(event)

--- a/src/Pane.coffee
+++ b/src/Pane.coffee
@@ -1,12 +1,24 @@
+# Pane
+# 
+# Internally used by SplitPane to create the resizable panes
+#
+# Vertical splitpane panes gets the classes "pane vertical"
+# Horizontal splitpane panes gets the classes "pane horizontal"
+# 
+# The first pane gets an added class "first"
+
 React = require 'react'
 H = React.DOM
 
 module.exports = class Pane extends React.Component
   
   @propTypes: {
-    split: React.PropTypes.oneOf(['vertical', 'horizontal']).isRequired
+    split: React.PropTypes.oneOf(['vertical', 'horizontal'])
     width: React.PropTypes.oneOfType([React.PropTypes.string,React.PropTypes.number])
   }
+
+  @defaultProps: ->
+    split: 'vertical'
 
   render: ->
     classNames = ["pane"]
@@ -21,6 +33,9 @@ module.exports = class Pane extends React.Component
       classNames.push('horizontal')
       style.height = @props.width if @props.width?
 
-    style.flex = 1 if !@props.width?
+    if @props.width
+      classNames.push("first")
+    else
+      style.flex = 1 
     
     H.div {style: style, className: classNames.join(" ")}, @props.children

--- a/src/Pane.coffee
+++ b/src/Pane.coffee
@@ -1,0 +1,29 @@
+React = require 'react'
+H = React.DOM
+
+module.exports = class Pane extends React.Component
+  constructor: ->
+    super
+    @state = { 
+      
+    }
+
+  handleClick: => 
+    @setState(count: @state.count + 1)
+
+  render: ->
+    classNames = ["pane"]
+    style =
+      flex: "0 0 auto"
+      position: "relative"
+
+    if @props.split == 'vertical'
+      classNames.push('vertical')
+      style.width = @props.width if @props.width?
+    else
+      classNames.push('horizontal')
+      style.height = @props.width if @props.width?
+
+    style.flex = 1 if !@props.width?
+    
+    H.div {style: style, className: classNames.join(" ")}, @props.children

--- a/src/Pane.coffee
+++ b/src/Pane.coffee
@@ -2,14 +2,11 @@ React = require 'react'
 H = React.DOM
 
 module.exports = class Pane extends React.Component
-  constructor: ->
-    super
-    @state = { 
-      
-    }
-
-  handleClick: => 
-    @setState(count: @state.count + 1)
+  
+  @propTypes: {
+    split: React.PropTypes.oneOf(['vertical', 'horizontal']).isRequired
+    width: React.PropTypes.oneOfType([React.PropTypes.string,React.PropTypes.number])
+  }
 
   render: ->
     classNames = ["pane"]

--- a/src/SampleComponent.coffee
+++ b/src/SampleComponent.coffee
@@ -4,19 +4,12 @@ SplitPane = require './SplitPane'
 
 # This is a nice sample component
 module.exports = class SampleComponent extends React.Component
-  constructor: ->
-    super
-    @state = { 
-    }
-
-  handleClick: => 
-
   render: ->
-    React.createElement(SplitPane, {split: "vertical", leftPaneSize: "20%", minLeftPaneSize: 100}, [
+    React.createElement(SplitPane, {split: "vertical", firstPaneSize: "20%", minFirstPaneSize: 100}, [
       H.div null
-      React.createElement(SplitPane, {split: "horizontal", leftPaneSize: "20%", minLeftPaneSize: 100}, [
+      React.createElement(SplitPane, {split: "horizontal", firstPaneSize: "20%", minFirstPaneSize: 100}, [
         H.div null
-        React.createElement(SplitPane, {split: "vertical", leftPaneSize: "20%", minLeftPaneSize: 100}, [
+        React.createElement(SplitPane, {split: "vertical", firstPaneSize: "20%", minFirstPaneSize: 100}, [
           H.div null
           H.div null
         ])

--- a/src/SampleComponent.coffee
+++ b/src/SampleComponent.coffee
@@ -9,7 +9,7 @@ module.exports = class SampleComponent extends React.Component
       H.div null
       React.createElement(SplitPane, {split: "horizontal", firstPaneSize: "20%", minFirstPaneSize: 100}, [
         H.div null
-        React.createElement(SplitPane, {split: "vertical", firstPaneSize: "20%", minFirstPaneSize: 100}, [
+        React.createElement(SplitPane, {split: "vertical", firstPaneSize: 300, minFirstPaneSize: 200}, [
           H.div null
           H.div null
         ])

--- a/src/SampleComponent.coffee
+++ b/src/SampleComponent.coffee
@@ -1,18 +1,24 @@
 React = require 'react'
 H = React.DOM
+SplitPane = require './SplitPane'
 
 # This is a nice sample component
 module.exports = class SampleComponent extends React.Component
   constructor: ->
     super
     @state = { 
-      count: 0
     }
 
   handleClick: => 
-    @setState(count: @state.count + 1)
 
   render: ->
-    H.div style: { padding: 10 },
-      H.button type: "button", onClick: @handleClick, "Increment"
-      "I'm at #{@state.count}"
+    React.createElement(SplitPane, {split: "vertical", leftPaneSize: "20%", minLeftPaneSize: 100}, [
+      H.div null
+      React.createElement(SplitPane, {split: "horizontal", leftPaneSize: "20%", minLeftPaneSize: 100}, [
+        H.div null
+        React.createElement(SplitPane, {split: "vertical", leftPaneSize: "20%", minLeftPaneSize: 100}, [
+          H.div null
+          H.div null
+        ])
+      ])
+    ])

--- a/src/SplitPane.coffee
+++ b/src/SplitPane.coffee
@@ -5,6 +5,13 @@ Divider = require './Divider'
 ReactDOM = require 'react-dom'
 
 module.exports = class SplitPane extends React.Component
+  
+  @propTypes = {
+    split: React.PropTypes.oneOf(['vertical', 'horizontal']).isRequired
+    firstPaneSize: React.PropTypes.oneOfType([React.PropTypes.string,React.PropTypes.number])
+    minFirstPaneSize: React.PropTypes.number
+  }
+
   constructor: ->
     super
     @state = { 
@@ -14,10 +21,6 @@ module.exports = class SplitPane extends React.Component
 
   @defaultProps: ->
     split: 'vertical'
-
-  #componentDidUpdate: =>
-  #  node = ReactDOM.findDOMNode(@refs.firstPane)
-  #  initialSize = if @props.split == "vertical" then node.offsetWidth else node.offsetHeight
 
   onMouseUp: => 
     if @state.resizing

--- a/src/SplitPane.coffee
+++ b/src/SplitPane.coffee
@@ -1,3 +1,15 @@
+#
+# SplitPane component
+# 
+# Create a resizable split pane with a draggable divider
+# 
+# React.createElement(SplitPane, {split: "vertical", firstPaneSize: "20%", minFirstPaneSize: 200}, [
+#   H.div null
+#   H.div null
+# ]) 
+#
+#
+
 React = require 'react'
 H = React.DOM
 Pane = require './Pane'
@@ -7,8 +19,13 @@ ReactDOM = require 'react-dom'
 module.exports = class SplitPane extends React.Component
   
   @propTypes = {
-    split: React.PropTypes.oneOf(['vertical', 'horizontal']).isRequired
+    # The split type "vertical" or "horizontal"
+    split: React.PropTypes.oneOf(['vertical', 'horizontal'])
+
+    # Size of the first pane. Takes a string with percentage value ("20%") or a number in pixels (300)
     firstPaneSize: React.PropTypes.oneOfType([React.PropTypes.string,React.PropTypes.number])
+
+    # Minimum size of the first pane. The first pane cannot be resized past this size. Takes a number in pixels
     minFirstPaneSize: React.PropTypes.number
   }
 

--- a/src/SplitPane.coffee
+++ b/src/SplitPane.coffee
@@ -8,7 +8,8 @@
 #   H.div null
 # ]) 
 #
-#
+# Vertical splitpane gets the classes "splitpane vertical"
+# Horizontal splitpane divider gets the classes "splitpane horizontal"
 
 React = require 'react'
 H = React.DOM
@@ -27,6 +28,10 @@ module.exports = class SplitPane extends React.Component
 
     # Minimum size of the first pane. The first pane cannot be resized past this size. Takes a number in pixels
     minFirstPaneSize: React.PropTypes.number
+
+    # Callback function that will be called when the resizing is done. 
+    # The current size of the firstpane is passed as first argument
+    onResize: React.PropTypes.func
   }
 
   constructor: ->
@@ -42,6 +47,7 @@ module.exports = class SplitPane extends React.Component
   onMouseUp: => 
     if @state.resizing
       @setState(resizing: false)
+      @props.onResize?(@state.firstPaneSize)
 
   onMouseDown: (event) =>
     dragStartAt = if @props.split == "vertical" then event.clientX else event.clientY

--- a/src/SplitPane.coffee
+++ b/src/SplitPane.coffee
@@ -1,0 +1,72 @@
+React = require 'react'
+H = React.DOM
+Pane = require './Pane'
+Divider = require './Divider'
+ReactDOM = require 'react-dom'
+
+module.exports = class SplitPane extends React.Component
+  constructor: ->
+    super
+    @state = { 
+      resizing: false
+      leftPaneSize: @props.leftPaneSize
+    }
+
+  @defaultProps: ->
+    split: 'vertical'
+
+  componentDidUpdate: =>
+    node = ReactDOM.findDOMNode(@refs.leftPane)
+    initialSize = if @props.split == "vertical" then node.offsetWidth else node.offsetHeight
+
+    console.log initialSize
+
+  onMouseUp: => 
+    if @state.resizing
+      @setState(resizing: false)
+
+  onMouseDown: (event) =>
+    dragStartAt = if @props.split == "vertical" then event.clientX else event.clientY
+    @setState({ resizing: true, dragStartAt: dragStartAt })
+
+  onMouseMove: (event) =>
+    if @state.resizing
+      if @props.split == "vertical"
+        leftPaneSize = ReactDOM.findDOMNode(@refs.leftPane).offsetWidth
+        currentPosition = event.clientX
+      else
+        leftPaneSize = ReactDOM.findDOMNode(@refs.leftPane).offsetHeight
+        currentPosition = event.clientY
+
+      newSize = leftPaneSize - (@state.dragStartAt - currentPosition)
+      @setState(dragStartAt: currentPosition)
+
+      if @props.minLeftPaneSize < newSize
+        @setState(leftPaneSize: newSize)
+        
+
+  render: ->
+    classNames = ["splitpane"]
+    style = 
+      display: "flex"
+      flex: 1
+      height: "100%"
+      position: "absolute"
+
+    if @props.split is "horizontal"  
+      style.width = "100%" 
+      style.top = 0
+      style.bottom = 0
+      style.flexDirection = "column"
+      classNames.push('horizontal')
+
+    if @props.split is "vertical"  
+      style.right = 0 
+      style.left = 0
+      style.flexDirection = "row"
+      classNames.push('vertical')
+
+    H.div {style: style, className: classNames.join(" "), onMouseMove: @onMouseMove, onMouseUp: @onMouseUp},
+      React.createElement(Pane,  {split: @props.split, width: @state.leftPaneSize , ref: "leftPane"}, @props.children[0]),
+      React.createElement(Divider, {ref: "divider", split: @props.split, onMouseDown: @onMouseDown }),
+      React.createElement(Pane,  {split: @props.split, ref:"rightPane"}, @props.children[1])

--- a/src/SplitPane.coffee
+++ b/src/SplitPane.coffee
@@ -9,17 +9,15 @@ module.exports = class SplitPane extends React.Component
     super
     @state = { 
       resizing: false
-      leftPaneSize: @props.leftPaneSize
+      firstPaneSize: @props.firstPaneSize
     }
 
   @defaultProps: ->
     split: 'vertical'
 
-  componentDidUpdate: =>
-    node = ReactDOM.findDOMNode(@refs.leftPane)
-    initialSize = if @props.split == "vertical" then node.offsetWidth else node.offsetHeight
-
-    console.log initialSize
+  #componentDidUpdate: =>
+  #  node = ReactDOM.findDOMNode(@refs.firstPane)
+  #  initialSize = if @props.split == "vertical" then node.offsetWidth else node.offsetHeight
 
   onMouseUp: => 
     if @state.resizing
@@ -32,17 +30,17 @@ module.exports = class SplitPane extends React.Component
   onMouseMove: (event) =>
     if @state.resizing
       if @props.split == "vertical"
-        leftPaneSize = ReactDOM.findDOMNode(@refs.leftPane).offsetWidth
+        firstPaneSize = ReactDOM.findDOMNode(@refs.firstPane).offsetWidth
         currentPosition = event.clientX
       else
-        leftPaneSize = ReactDOM.findDOMNode(@refs.leftPane).offsetHeight
+        firstPaneSize = ReactDOM.findDOMNode(@refs.firstPane).offsetHeight
         currentPosition = event.clientY
 
-      newSize = leftPaneSize - (@state.dragStartAt - currentPosition)
+      newSize = firstPaneSize - (@state.dragStartAt - currentPosition)
       @setState(dragStartAt: currentPosition)
 
-      if @props.minLeftPaneSize < newSize
-        @setState(leftPaneSize: newSize)
+      if @props.minFirstPaneSize < newSize
+        @setState(firstPaneSize: newSize)
         
 
   render: ->
@@ -67,6 +65,6 @@ module.exports = class SplitPane extends React.Component
       classNames.push('vertical')
 
     H.div {style: style, className: classNames.join(" "), onMouseMove: @onMouseMove, onMouseUp: @onMouseUp},
-      React.createElement(Pane,  {split: @props.split, width: @state.leftPaneSize , ref: "leftPane"}, @props.children[0]),
+      React.createElement(Pane,  {split: @props.split, width: @state.firstPaneSize , ref: "firstPane"}, @props.children[0]),
       React.createElement(Divider, {ref: "divider", split: @props.split, onMouseDown: @onMouseDown }),
       React.createElement(Pane,  {split: @props.split, ref:"rightPane"}, @props.children[1])

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+.splitpane .divider{
+	background: #aeaeae;
+}
+
+.splitpane .divider.vertical{
+	width: 4px;
+	cursor: col-resize;
+}
+
+.splitpane .divider.horizontal{
+	height: 4px;
+	cursor: row-resize;
+}


### PR DESCRIPTION
Split Pane component was created for #1 

- ~~be able to split vertically or horizontally~~
- ~~have a percentage passed in that determines the relative sizes of the two panes~~
- ~~call a prop callback with any changes to the split percentage~~
- ~~have a nice draggable splitter line in between the parts~~
- ~~use flexbox for easy layout. We only support modern browsers in mWater~~

Currently the initial width is set in percentage. Once the resizing starts, the pane's width/height is set in pixels. Please check.

```
render: ->
    React.createElement(SplitPane, {split: "vertical", leftPaneSize: "20%", minLeftPaneSize: 100}, [
      H.div null
      React.createElement(SplitPane, {split: "horizontal", leftPaneSize: "20%", minLeftPaneSize: 100}, [
        H.div null
        React.createElement(SplitPane, {split: "vertical", leftPaneSize: "20%", minLeftPaneSize: 100}, [
          H.div null
          H.div null
        ])
      ])
    ])
```


