### PR TITLE
implemented element resize listener for AutoSizeComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "",
   "dependencies": {
     "async": "^1.5.0",
+    "element-resize-event": "^2.0.3",
     "lodash": "^3.10.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3"

--- a/src/AutoSizeComponent.coffee
+++ b/src/AutoSizeComponent.coffee
@@ -1,5 +1,6 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
+elementResizeEvent = require 'element-resize-event'
 H = React.DOM
 
 # Automatically injects the width or height of the DOM element into the
@@ -15,6 +16,7 @@ module.exports = class AutoSizeComponent extends React.Component
   componentDidMount: ->
     # Listen for changes
     $(window).on('resize', @updateSize)
+    elementResizeEvent(ReactDOM.findDOMNode(this), @updateSize)
     @updateSize()
 
   componentWillUnmount: ->

--- a/src/SampleComponent.coffee
+++ b/src/SampleComponent.coffee
@@ -1,16 +1,31 @@
 React = require 'react'
 H = React.DOM
 SplitPane = require './SplitPane'
+AutoSizeComponent = require './AutoSizeComponent'
+R = React.createElement
 
 # This is a nice sample component
 module.exports = class SampleComponent extends React.Component
   render: ->
+
+    style1 =
+      height: 300
+      width: 300
+      border: "1px solid #000"
+
     React.createElement(SplitPane, {split: "vertical", firstPaneSize: "20%", minFirstPaneSize: 100}, [
-      H.div null
+#      H.div null
+      R AutoSizeComponent, {injectWidth: true, injectHeight: true},
+        H.div null,
+          "width only"
       React.createElement(SplitPane, {split: "horizontal", firstPaneSize: "20%", minFirstPaneSize: 100}, [
-        H.div null
+        R AutoSizeComponent, {injectWidth: true, injectHeight: true},
+          H.div {height: 300},
+            "height"
         React.createElement(SplitPane, {split: "vertical", firstPaneSize: 300, minFirstPaneSize: 200}, [
-          H.div null
+          R AutoSizeComponent, {injectWidth: true, injectHeight: true},
+            H.div {height: 300},
+              "width and height"
           H.div null
         ])
       ])

--- a/src/demo.coffee
+++ b/src/demo.coffee
@@ -35,15 +35,17 @@ $ ->
   #   React.createElement(SampleComponent)
   #   H.br()
 
-  elem = R ModalPopupComponent, { header: "OUTER", size: "large" }, 
-    H.div null, "OUTER MODAL"
-    H.div null, "OUTER MODAL"
-    H.div null, "OUTER MODAL"
-    H.div null, "OUTER MODAL"
-    H.div null, "OUTER MODAL"
-    R ModalPopupComponent, { header: "INNER" }, 
-      H.div null, "INNER MODAL"
-      H.div null, "INNER MODAL"
+#  elem = R ModalPopupComponent, { header: "OUTER", size: "large" },
+#    H.div null, "OUTER MODAL"
+#    H.div null, "OUTER MODAL"
+#    H.div null, "OUTER MODAL"
+#    H.div null, "OUTER MODAL"
+#    H.div null, "OUTER MODAL"
+#    R ModalPopupComponent, { header: "INNER" },
+#      H.div null, "INNER MODAL"
+#      H.div null, "INNER MODAL"
+
+  elem = R SampleComponent
 
 
   ReactDOM.render(elem, document.getElementById("main"))


### PR DESCRIPTION
Implemented https://github.com/KyleAMathews/element-resize-event for AutoSizeComponent

Unregistering event listener and cleaning up added `<object>` elements are not yet supported by the library. I will see if I can get a fix to that library. After that a simple update would be required.