### PR TITLE
different implementation of element resize detector with listener unregister

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "classnames": "^2.2.1",
-    "element-resize-event": "^2.0.3",
+    "element-resize-detector": "^1.0.3",
     "lodash": "^3.10.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",

--- a/src/AutoSizeComponent.coffee
+++ b/src/AutoSizeComponent.coffee
@@ -1,6 +1,6 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-elementResizeEvent = require 'element-resize-event'
+elementResizeDetectorMaker = require 'element-resize-detector'
 H = React.DOM
 
 # Automatically injects the width or height of the DOM element into the
@@ -13,15 +13,17 @@ module.exports = class AutoSizeComponent extends React.Component
 
   constructor: ->
     @state = { width: null, height: null }
+    @resizeDetector = elementResizeDetectorMaker()
 
   componentDidMount: ->
     # Listen for changes
     $(window).on('resize', @updateSize)
-    elementResizeEvent(ReactDOM.findDOMNode(this), @updateSize)
+    @resizeDetector.listenTo(ReactDOM.findDOMNode(this), @updateSize)
     @updateSize()
 
   componentWillUnmount: ->
     # Stop listening to resize events
+    @resizeDetector.removeListener(ReactDOM.findDOMNode(this), @updateSize)
     $(window).off('resize', @updateSize)
 
   updateSize: =>


### PR DESCRIPTION
The crash was caused because the event listener was not unregistered on unmount. This new library has implementation for unregistering event listener. 
This should fix the crash.