### PR TITLE
change element resize library

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "async": "^1.5.0",
     "classnames": "^2.2.1",
-    "element-resize-detector": "^1.0.3",
     "lodash": "^3.10.1",
     "react": "^0.14.3",
+    "react-component-resizable": "^0.3.0",
     "react-dom": "^0.14.3",
     "react-overlays": "^0.5.4"
   },

--- a/src/AutoSizeComponent.coffee
+++ b/src/AutoSizeComponent.coffee
@@ -1,7 +1,8 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-elementResizeDetectorMaker = require 'element-resize-detector'
+Resizable = require 'react-component-resizable'
 H = React.DOM
+R = React.createElement
 
 # Automatically injects the width or height of the DOM element into the
 # child component, updating as window resizes. 
@@ -13,23 +14,14 @@ module.exports = class AutoSizeComponent extends React.Component
 
   constructor: ->
     @state = { width: null, height: null }
-    @resizeDetector = elementResizeDetectorMaker()
 
   componentDidMount: ->
     # Listen for changes
     $(window).on('resize', @updateSize)
-    try
-      @resizeDetector.listenTo(ReactDOM.findDOMNode(this), @updateSize)
-    catch error
-
     @updateSize()
 
   componentWillUnmount: ->
     # Stop listening to resize events
-    try
-      @resizeDetector.removeListener(ReactDOM.findDOMNode(this), @updateSize)
-    catch error
-      
     $(window).off('resize', @updateSize)
 
   updateSize: =>
@@ -58,4 +50,4 @@ module.exports = class AutoSizeComponent extends React.Component
     if @props.injectHeight
       style.height = "100%"
 
-    return H.div(style: style, innerElem)
+    return R Resizable, {style: style, onResize: @updateSize}, innerElem


### PR DESCRIPTION
I have changed the element resize library with a react component itself. This should handle the unmounting of the element itself. 

The library detects resize using a different strategy and does not throw any exception.