### PR TITLE
make modal content non scrollable when needed

### DIFF
--- a/lib/ModalPopupComponent.js
+++ b/lib/ModalPopupComponent.js
@@ -30,7 +30,12 @@ module.exports = ModalPopupComponent = (function(superClass) {
     footer: React.PropTypes.node,
     size: React.PropTypes.string,
     onClose: React.PropTypes.func,
-    showCloseX: React.PropTypes.bool
+    showCloseX: React.PropTypes.bool,
+    scrollEnabled: React.PropTypes.bool.isRequired
+  };
+
+  ModalPopupComponent.defaultProps = {
+    scrollEnabled: true
   };
 
   ModalPopupComponent.prototype.close = function() {
@@ -113,15 +118,20 @@ ModalComponentContent = (function(superClass) {
     footer: React.PropTypes.node,
     size: React.PropTypes.string,
     showCloseX: React.PropTypes.bool,
-    onClose: React.PropTypes.func
+    onClose: React.PropTypes.func,
+    scrollEnabled: React.PropTypes.bool.isRequired
   };
 
   ModalComponentContent.prototype.componentDidUpdate = function(prevProps, prevState) {
-    return this.calculateModalBodyHeight();
+    if (this.props.scrollEnabled) {
+      return this.calculateModalBodyHeight();
+    }
   };
 
   ModalComponentContent.prototype.componentDidMount = function() {
-    return this.calculateModalBodyHeight();
+    if (this.props.scrollEnabled) {
+      return this.calculateModalBodyHeight();
+    }
   };
 
   ModalComponentContent.prototype.calculateModalBodyHeight = function() {
@@ -129,7 +139,6 @@ ModalComponentContent = (function(superClass) {
     header = $(this.refs.modalHeader);
     footer = $(this.refs.modalFooter);
     scale = toPX("vh");
-    console.log(scale);
     maxHeight = 98 * scale - ((header != null ? header.outerHeight() : void 0) + (footer != null ? footer.outerHeight() : void 0) + 60);
     css = {
       maxHeight: maxHeight + "px",
@@ -139,6 +148,11 @@ ModalComponentContent = (function(superClass) {
   };
 
   ModalComponentContent.prototype.render = function() {
+    var style;
+    style = this.props.scrollEnabled ? {
+      maxHeight: "90vh",
+      overflowY: "auto"
+    } : {};
     return H.div({
       className: "modal-content"
     }, this.props.header ? H.div({
@@ -152,10 +166,7 @@ ModalComponentContent = (function(superClass) {
       className: "modal-title"
     }, this.props.header)) : void 0, H.div({
       className: "modal-body",
-      style: {
-        maxHeight: "90vh",
-        overflowY: "auto"
-      },
+      style: style,
       ref: "modalBody"
     }, this.props.children), this.props.footer ? H.div({
       className: "modal-footer",

--- a/lib/demo.js
+++ b/lib/demo.js
@@ -414,6 +414,21 @@ BlocksComponent = (function(superClass) {
 
 $(function() {
   var elem;
+  ModalPopupComponent.show((function(_this) {
+    return function(onClose) {
+      return React.createElement(ModalPopupComponent, {
+        footer: H.button({
+          type: "button",
+          className: "btn btn-default",
+          onClick: onClose
+        }, "TEST"),
+        header: "This is a test modal",
+        scrollEnabled: false
+      }, _.map(_.range(1, 100), function(x) {
+        return H.div(null, "" + x);
+      }));
+    };
+  })(this));
   elem = H.div(null, React.createElement(BlocksComponent), H.br());
   return ReactDOM.render(elem, document.getElementById("main"));
 });

--- a/src/ModalPopupComponent.coffee
+++ b/src/ModalPopupComponent.coffee
@@ -14,6 +14,10 @@ module.exports = class ModalPopupComponent extends React.Component
     size: React.PropTypes.string # "large" for large,  "small" for small and none for standard
     onClose: React.PropTypes.func # callback function to be called when close is requested
     showCloseX: React.PropTypes.bool # True to show close 'x' at top right
+    scrollEnabled: React.PropTypes.bool.isRequired # Is content scrolling enabled see https://github.com/mWater/react-library/issues/31
+
+  @defaultProps:
+    scrollEnabled: true
 
   close: =>
     @props.onClose?()
@@ -91,19 +95,21 @@ class ModalComponentContent extends React.Component
     size: React.PropTypes.string # "large" for large
     showCloseX: React.PropTypes.bool # True to show close 'x' at top right
     onClose: React.PropTypes.func # callback function to be called when close is requested
+    scrollEnabled: React.PropTypes.bool.isRequired # Is content scrolling enabled see https://github.com/mWater/react-library/issues/31
 
   componentDidUpdate: (prevProps, prevState) ->
-    @calculateModalBodyHeight()
+    if @props.scrollEnabled
+      @calculateModalBodyHeight()
 
   componentDidMount: ->
-    @calculateModalBodyHeight()
+    if @props.scrollEnabled
+      @calculateModalBodyHeight()
 
   calculateModalBodyHeight: ->
     header = $(@refs.modalHeader)
     footer = $(@refs.modalFooter)
 
     scale = toPX("vh")
-    console.log scale
     maxHeight = 98 * scale - (header?.outerHeight() + footer?.outerHeight() + 60)
 
     css =
@@ -113,6 +119,7 @@ class ModalComponentContent extends React.Component
     $(@refs.modalBody).css(css)
 
   render: ->
+    style = if @props.scrollEnabled then {maxHeight: "90vh", overflowY: "auto"} else {}
     H.div className: "modal-content",
       if @props.header
         H.div className: "modal-header", ref: "modalHeader",
@@ -121,7 +128,7 @@ class ModalComponentContent extends React.Component
               H.span onClick: @props.onClose, "\u00d7"
           H.h4 className: "modal-title",
             @props.header
-      H.div className: "modal-body", style: { maxHeight: "90vh", overflowY: "auto"}, ref: "modalBody",
+      H.div className: "modal-body", style: style, ref: "modalBody",
         @props.children
       if @props.footer
         H.div className: "modal-footer", ref: "modalFooter",

--- a/src/ModalPopupComponent.coffee
+++ b/src/ModalPopupComponent.coffee
@@ -14,10 +14,7 @@ module.exports = class ModalPopupComponent extends React.Component
     size: React.PropTypes.string # "large" for large,  "small" for small and none for standard
     onClose: React.PropTypes.func # callback function to be called when close is requested
     showCloseX: React.PropTypes.bool # True to show close 'x' at top right
-    scrollEnabled: React.PropTypes.bool.isRequired # Is content scrolling enabled see https://github.com/mWater/react-library/issues/31
-
-  @defaultProps:
-    scrollEnabled: true
+    scrollDisabled: React.PropTypes.bool # Force disable content scrolling see https://github.com/mWater/react-library/issues/31
 
   close: =>
     @props.onClose?()
@@ -95,31 +92,28 @@ class ModalComponentContent extends React.Component
     size: React.PropTypes.string # "large" for large
     showCloseX: React.PropTypes.bool # True to show close 'x' at top right
     onClose: React.PropTypes.func # callback function to be called when close is requested
-    scrollEnabled: React.PropTypes.bool.isRequired # Is content scrolling enabled see https://github.com/mWater/react-library/issues/31
+    scrollDisabled: React.PropTypes.bool # Force content scrolling disable see https://github.com/mWater/react-library/issues/31
 
   componentDidUpdate: (prevProps, prevState) ->
-    if @props.scrollEnabled
-      @calculateModalBodyHeight()
+    @calculateModalBodyHeight()
 
   componentDidMount: ->
-    if @props.scrollEnabled
-      @calculateModalBodyHeight()
+    @calculateModalBodyHeight()
 
   calculateModalBodyHeight: ->
     header = $(@refs.modalHeader)
     footer = $(@refs.modalFooter)
+    content = $(@refs.modalBody)
 
-    scale = toPX("vh")
-    maxHeight = 98 * scale - (header?.outerHeight() + footer?.outerHeight() + 60)
+    if $(window).height() < $(content).height() and not @props.scrollDisabled
 
-    css =
-      maxHeight: "#{maxHeight}px"
-      overFlowY: "auto"
+      scale = toPX("vh")
+      maxHeight = 98 * scale - (header?.outerHeight() + footer?.outerHeight() + 60)
 
-    $(@refs.modalBody).css(css)
+      content.css(maxHeight: "#{maxHeight}px", overflowY: "auto")
 
   render: ->
-    style = if @props.scrollEnabled then {maxHeight: "90vh", overflowY: "auto"} else {}
+    style = if not @props.scrollDisabled then {} else {}
     H.div className: "modal-content",
       if @props.header
         H.div className: "modal-header", ref: "modalHeader",

--- a/src/demo.coffee
+++ b/src/demo.coffee
@@ -290,8 +290,8 @@ $ ->
   ModalPopupComponent.show((onClose) =>
     return React.createElement(ModalPopupComponent, {
       footer: H.button(type: "button", className: "btn btn-default", onClick: onClose, "TEST")
+      scrollDisabled: true
       header: "This is a test modal"
-      scrollEnabled: false
       }, _.map(_.range(1, 100), (x) -> H.div null, "#{x}"))
     )
 

--- a/src/demo.coffee
+++ b/src/demo.coffee
@@ -287,12 +287,13 @@ $ ->
   #   R(Block)
   #   R(Block)
   
-   # ModalPopupComponent.show((onClose) =>
-   #   return React.createElement(ModalPopupComponent, {
-   #     footer: H.button(type: "button", className: "btn btn-default", onClick: onClose, "TEST")
-   #     header: "This is a test modal"
-   #     }, _.map(_.range(1, 100), (x) -> H.div null, "#{x}"))
-   #   )
+  ModalPopupComponent.show((onClose) =>
+    return React.createElement(ModalPopupComponent, {
+      footer: H.button(type: "button", className: "btn btn-default", onClick: onClose, "TEST")
+      header: "This is a test modal"
+      scrollEnabled: false
+      }, _.map(_.range(1, 100), (x) -> H.div null, "#{x}"))
+    )
 
 
   # elem = H.div null,


### PR DESCRIPTION
In reference to #31 

There is currently no way we can have both these feature at one place
- Content scrolling 
- Dropdown overflow

So this is kind of a workaround, where by default modal content is scrollable and adjusts to the viewport, but for cases when we know modals would be small or need to support dropdown components, we can disable content scrolling